### PR TITLE
Minor follow up tidy

### DIFF
--- a/src/main/java/iog/psg/cardano/jpi/CardanoApiBuilder.java
+++ b/src/main/java/iog/psg/cardano/jpi/CardanoApiBuilder.java
@@ -1,7 +1,6 @@
 package iog.psg.cardano.jpi;
 
 import akka.actor.ActorSystem;
-import iog.psg.cardano.ApiRequestExecutor$;
 import scala.concurrent.ExecutionContext;
 
 import java.util.Objects;
@@ -64,9 +63,9 @@ public class CardanoApiBuilder {
         HelpExecute helpExecute;
 
         if(apiRequestExecutor == null) {
-            helpExecute = new HelpExecute(ApiRequestExecutor$.MODULE$, ec, actorSystem);
+            helpExecute = new HelpExecute(ec, actorSystem);
         } else {
-            helpExecute = new HelpExecute(ApiRequestExecutor$.MODULE$, ec, actorSystem) {
+            helpExecute = new HelpExecute(ec, actorSystem) {
                 @Override
                 public <T> CompletionStage<T> execute(iog.psg.cardano.CardanoApi.CardanoApiRequest<T> request) throws CardanoApiException {
                     return apiRequestExecutor.execute(request);

--- a/src/main/scala/iog/psg/cardano/jpi/HelpExecute.scala
+++ b/src/main/scala/iog/psg/cardano/jpi/HelpExecute.scala
@@ -27,7 +27,9 @@ object HelpExecute {
   }.toMap
 }
 
-class HelpExecute(implicit executor: ApiRequestExecutor, ec: ExecutionContext, as: ActorSystem) extends JApiRequestExecutor {
+class HelpExecute(implicit ec: ExecutionContext, as: ActorSystem) extends JApiRequestExecutor {
+
+  implicit val executor: ApiRequestExecutor = ApiRequestExecutor
 
   @throws(classOf[CardanoApiException])
   private def unwrapResponse[T](resp: CardanoApiResponse[T]): T = resp match {

--- a/src/test/scala/iog/psg/cardano/jpi/CardanoJpiSpec.scala
+++ b/src/test/scala/iog/psg/cardano/jpi/CardanoJpiSpec.scala
@@ -2,7 +2,7 @@ package iog.psg.cardano.jpi
 
 import java.util.concurrent.TimeUnit
 
-import iog.psg.cardano.CardanoApiCodec.{GenericMnemonicSentence, Wallet}
+import iog.psg.cardano.CardanoApiCodec.GenericMnemonicSentence
 import iog.psg.cardano.util.Configure
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers


### PR DESCRIPTION
We don't need to expose the scala request executor to the java API,the executor functionality is overridable via the java withApiExecutor method.