### PR TITLE
Fix QuantityUnit decode

### DIFF
--- a/src/main/scala/iog/psg/cardano/CardanoApiCodec.scala
+++ b/src/main/scala/iog/psg/cardano/CardanoApiCodec.scala
@@ -75,6 +75,17 @@ object CardanoApiCodec {
   private[cardano] implicit val encodeWallet: Encoder[Wallet] = dropNulls(deriveConfiguredEncoder)
   private[cardano] implicit val encodeBlock: Encoder[Block] = dropNulls(deriveConfiguredEncoder)
 
+  private[cardano] implicit val decodeQuantityUnit: Decoder[QuantityUnit] = (c: HCursor) => {
+    for {
+      quantityDC <- c.downField("quantity").as[BigDecimal]
+      quantity <-  Try(quantityDC.toLong).toEither.left.map(_ => DecodingFailure("quantity", c.history))
+      unitsStr <- c.downField("unit").as[String]
+      units <- Try(Units.withName(unitsStr)).toEither.left.map(_ => DecodingFailure("unit", c.history))
+    } yield {
+      QuantityUnit(quantity, units)
+    }
+  }
+
   sealed trait MetadataValue
 
   sealed trait MetadataKey extends MetadataValue

--- a/src/main/scala/iog/psg/cardano/CardanoApiCodec.scala
+++ b/src/main/scala/iog/psg/cardano/CardanoApiCodec.scala
@@ -279,10 +279,7 @@ object CardanoApiCodec {
     val inLedger = Value("in_ledger")
   }
 
-  final case class QuantityUnit[T] private(
-                           quantity: T,
-                           unit: Units
-                         )
+  @ConfiguredJsonCodec(encodeOnly = true) final case class QuantityUnit[T] private(quantity: T, unit: Units)
 
   object QuantityUnit {
     def apply(quantity: Long, unit: Units): QuantityUnit[Long] = new QuantityUnit(quantity, unit)

--- a/src/test/java/iog/psg/cardano/jpi/JpiResponseCheck.java
+++ b/src/test/java/iog/psg/cardano/jpi/JpiResponseCheck.java
@@ -87,7 +87,7 @@ public class JpiResponseCheck {
 
     }
 
-    public CardanoApiCodec.CreateTransactionResponse paymentToSelf(String wallet1Id, String passphrase, int amountToTransfer, Map<String, String> metadata) throws Exception {
+    public CardanoApiCodec.CreateTransactionResponse paymentToSelf(String wallet1Id, String passphrase, long amountToTransfer, Map<String, String> metadata) throws Exception {
 
         Map<Long, String> metadataLongKey = new HashMap();
         metadata.forEach((k,v) -> {

--- a/src/test/java/iog/psg/cardano/jpi/JpiResponseCheck.java
+++ b/src/test/java/iog/psg/cardano/jpi/JpiResponseCheck.java
@@ -99,8 +99,7 @@ public class JpiResponseCheck {
         String unusedAddrIdWallet1 = unused.get(0).id();
         CardanoApiCodec.QuantityUnit amount = new CardanoApiCodec.QuantityUnit(amountToTransfer, CardanoApiCodec.Units$.MODULE$.lovelace());
         List<CardanoApiCodec.Payment> payments = Collections.singletonList(new CardanoApiCodec.Payment(unusedAddrIdWallet1, amount));
-        CardanoApiCodec.EstimateFeeResponse response = jpi.estimateFee(wallet1Id, payments).toCompletableFuture().get(timeout, timeoutUnit);
-        long max = response.estimatedMax().quantity();
+        jpi.estimateFee(wallet1Id, payments).toCompletableFuture().get(timeout, timeoutUnit);
         return jpi.createTransaction(wallet1Id, passphrase, payments, in, null).toCompletableFuture().get(timeout, timeoutUnit);
 
     }

--- a/src/test/scala/iog/psg/cardano/CardanoApiCodecSpec.scala
+++ b/src/test/scala/iog/psg/cardano/CardanoApiCodecSpec.scala
@@ -76,9 +76,24 @@ class CardanoApiCodecSpec extends AnyFlatSpec with Matchers with DummyModel {
     b.asJson.noSpaces shouldBe """{"slot_number":1,"epoch_number":2,"height":{"quantity":42000000,"unit":"lovelace"}}"""
   }
 
-  "Quantity" should "be decoded to Long" in {
+  "Quantity" should "be decoded to Double" in {
     val decodedQU = decode[QuantityUnit[Double]]("""{"quantity":123.45,"unit":"lovelace"}""")
     decodedQU.getOrElse(fail("Not decoded")).quantity shouldBe 123.45
+  }
+
+  it should "be decoded to Long" in {
+    val decodedQU = decode[QuantityUnit[Long]]("""{"quantity":123,"unit":"lovelace"}""")
+    decodedQU.getOrElse(fail("Not decoded")).quantity shouldBe 123
+  }
+
+  it should "be encoded to Double" in {
+    val qu = QuantityUnit(123.45, Units.lovelace)
+    qu.asJson.noSpaces shouldBe """{"quantity":123.45,"unit":"lovelace"}"""
+  }
+
+  it should "be encoded to Long" in {
+    val qu = QuantityUnit(123, Units.lovelace)
+    qu.asJson.noSpaces shouldBe """{"quantity":123,"unit":"lovelace"}"""
   }
 
 }

--- a/src/test/scala/iog/psg/cardano/CardanoApiCodecSpec.scala
+++ b/src/test/scala/iog/psg/cardano/CardanoApiCodecSpec.scala
@@ -1,6 +1,7 @@
 package iog.psg.cardano
 
-import io.circe.syntax.EncoderOps
+import io.circe.jawn.decode
+import io.circe.syntax._
 import iog.psg.cardano.CardanoApiCodec._
 import iog.psg.cardano.util.DummyModel
 import org.scalatest.flatspec.AnyFlatSpec
@@ -73,6 +74,11 @@ class CardanoApiCodecSpec extends AnyFlatSpec with Matchers with DummyModel {
     )
 
     b.asJson.noSpaces shouldBe """{"slot_number":1,"epoch_number":2,"height":{"quantity":42000000,"unit":"lovelace"}}"""
+  }
+
+  "Quantity" should "be decoded to Long" in {
+    val decodedQU = decode[QuantityUnit]("""{"quantity":123.45,"unit":"lovelace"}""")
+    decodedQU.getOrElse(fail("Not decoded")).quantity shouldBe 123
   }
 
 }

--- a/src/test/scala/iog/psg/cardano/CardanoApiCodecSpec.scala
+++ b/src/test/scala/iog/psg/cardano/CardanoApiCodecSpec.scala
@@ -77,8 +77,8 @@ class CardanoApiCodecSpec extends AnyFlatSpec with Matchers with DummyModel {
   }
 
   "Quantity" should "be decoded to Long" in {
-    val decodedQU = decode[QuantityUnit]("""{"quantity":123.45,"unit":"lovelace"}""")
-    decodedQU.getOrElse(fail("Not decoded")).quantity shouldBe 123
+    val decodedQU = decode[QuantityUnit[Double]]("""{"quantity":123.45,"unit":"lovelace"}""")
+    decodedQU.getOrElse(fail("Not decoded")).quantity shouldBe 123.45
   }
 
 }

--- a/src/test/scala/iog/psg/cardano/util/ModelCompare.scala
+++ b/src/test/scala/iog/psg/cardano/util/ModelCompare.scala
@@ -77,7 +77,7 @@ trait ModelCompare extends Matchers {
     compareQuantityUnitOpts(decoded.syncProgress.progress, expected.syncProgress.progress)
   }
 
-  final def compareQuantityUnitOpts(decoded: Option[QuantityUnit], expected: Option[QuantityUnit]): Assertion = {
+  final def compareQuantityUnitOpts[T](decoded: Option[QuantityUnit[T]], expected: Option[QuantityUnit[T]]): Assertion = {
     if (decoded.isEmpty && expected.isEmpty) assert(true)
     else (for {
       decodedQU <- decoded
@@ -85,7 +85,7 @@ trait ModelCompare extends Matchers {
     } yield compareQuantityUnit(decodedQU, expectedQU)).getOrElse(assert(false, "one of units is none"))
   }
 
-  final def compareQuantityUnit(decoded: QuantityUnit, expected: QuantityUnit): Assertion = {
+  final def compareQuantityUnit[T](decoded: QuantityUnit[T], expected: QuantityUnit[T]): Assertion = {
     decoded.unit.toString shouldBe expected.unit.toString
     decoded.quantity shouldBe expected.quantity
   }


### PR DESCRIPTION
So we are leaving Long type, but when wallet API will return doubles ( while syncing ) then it will decode properly.
Probably in future we would like to show the users doubles, but for now fast fix to avoid errors.