### PR TITLE
Fix for inablity to use encoders and decoders outside the cardano pac…

### DIFF
--- a/src/it/scala/iog/psg/cardano/CardanoApiMainITSpec.scala
+++ b/src/it/scala/iog/psg/cardano/CardanoApiMainITSpec.scala
@@ -3,9 +3,9 @@ package iog.psg.cardano
 import java.time.ZonedDateTime
 
 import akka.actor.ActorSystem
-import io.circe.Encoder
 import io.circe.generic.auto._
 import io.circe.parser.{decode, _}
+import iog.psg.cardano.CardanoApiCodec.ImplicitCodecs._
 import iog.psg.cardano.CardanoApiCodec.WalletAddressId
 import iog.psg.cardano.CardanoApiMain.CmdLine
 import iog.psg.cardano.TestWalletsConfig.baseUrl

--- a/src/main/scala/iog/psg/cardano/CardanoApiImpl.scala
+++ b/src/main/scala/iog/psg/cardano/CardanoApiImpl.scala
@@ -17,6 +17,7 @@ import scala.concurrent.{ExecutionContext, Future}
 private class CardanoApiImpl(baseUriWithPort: String)(implicit ec: ExecutionContext, as: ActorSystem) extends CardanoApi {
 
   import CardanoApiCodec._
+  import CardanoApiCodec.ImplicitCodecs._
   import AddressFilter.AddressFilter
   import iog.psg.cardano.CardanoApi._
 

--- a/src/main/scala/iog/psg/cardano/CardanoApiMain.scala
+++ b/src/main/scala/iog/psg/cardano/CardanoApiMain.scala
@@ -7,10 +7,9 @@ import akka.actor.ActorSystem
 import iog.psg.cardano.CardanoApi.CardanoApiOps.{CardanoApiRequestFOps, CardanoApiRequestOps}
 import iog.psg.cardano.CardanoApi.{CardanoApiResponse, ErrorMessage, Order, defaultMaxWaitTime}
 import CardanoApiCodec.{AddressFilter, GenericMnemonicSecondaryFactor, GenericMnemonicSentence, Payment, Payments, QuantityUnit, Units}
-import io.circe.Encoder
 import iog.psg.cardano.util.StringToMetaMapParser.toMetaMap
 import iog.psg.cardano.util._
-
+import CardanoApiCodec.ImplicitCodecs._
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
 

--- a/src/test/scala/iog/psg/cardano/TxMetadataCodecSpec.scala
+++ b/src/test/scala/iog/psg/cardano/TxMetadataCodecSpec.scala
@@ -1,9 +1,9 @@
 package iog.psg.cardano
 
 import akka.util.ByteString
-import io.circe.parser.parse
 import io.circe.syntax.EncoderOps
 import io.circe.{ParsingFailure, parser}
+import iog.psg.cardano.CardanoApiCodec.ImplicitCodecs._
 import iog.psg.cardano.CardanoApiCodec._
 import iog.psg.cardano.util.DummyModel
 import org.scalatest.flatspec.AnyFlatSpec

--- a/src/test/scala/iog/psg/cardano/util/InMemoryCardanoApi.scala
+++ b/src/test/scala/iog/psg/cardano/util/InMemoryCardanoApi.scala
@@ -16,6 +16,7 @@ import iog.psg.cardano.jpi.CardanoApiException
 import iog.psg.cardano.{ApiRequestExecutor, CardanoApi}
 import org.scalatest.Assertions
 import org.scalatest.concurrent.ScalaFutures
+import iog.psg.cardano.CardanoApiCodec.ImplicitCodecs._
 
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
 

--- a/src/test/scala/iog/psg/external/CardanoApiCodecSpec.scala
+++ b/src/test/scala/iog/psg/external/CardanoApiCodecSpec.scala
@@ -1,12 +1,19 @@
-package iog.psg.cardano
+package iog.psg.external
 
 import io.circe.jawn.decode
 import io.circe.syntax._
+import iog.psg.cardano.CardanoApiCodec.ImplicitCodecs._
 import iog.psg.cardano.CardanoApiCodec._
 import iog.psg.cardano.util.DummyModel
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+/**
+ * NB It's import that this class is in a package that is 'external' to the
+ * cardano package in order to test that these encoders and decoders are
+ * available to clients and are not privately scoped to the implementation package
+ * (using private[cardano])
+ */
 class CardanoApiCodecSpec extends AnyFlatSpec with Matchers with DummyModel {
 
   "Encode class with Nones" should "drop nulls in Delegation" in {


### PR DESCRIPTION
The encoders were marked private to the cardano package. 
This meant they could not be used in the alarmsservice (for example) 
This fix exposes them from the Implicits object.
The implicits object was added to allow the Codec and the implicits to be imported seperatley. 
  